### PR TITLE
Activate aws organizations for infra-aws

### DIFF
--- a/infra-aws/__main__.py
+++ b/infra-aws/__main__.py
@@ -20,6 +20,7 @@ organization = asterion_organization.org(
 # Activate aws organizations if it hasn't already
 if not organization.org_exists:
     organization.create_org()
+pulumi.export("Asterion aws org ID", organization.org.id)
 
 # Stand up dedicated vpc and internet gateway
 vpc = aws.ec2.Vpc("asterion-infra-vpc", cidr_block="10.0.0.0/16", enable_dns_hostnames=True)

--- a/infra-aws/__main__.py
+++ b/infra-aws/__main__.py
@@ -1,44 +1,19 @@
 """A pulumi program to deploy asterion-digital infra on aws."""
 
 # Import dependencies
+import asterion_organization
 import requests
 import pulumi
 import pulumi_aws as aws
 import pulumi_command as command
 from pulumi import Output
 
-# Create an asterion organization object
-class asterion_organization:
-
-    # Default constructor
-    def __init__(self, name, org):
-        self.name = name
-        self.org = org
-
-    # Create an aws org for the current account
-    def create_org(self):
-        
-        # Create an organization for this current account
-        self.org = aws.organizations.Organization(self.name,
-            aws_service_access_principals=[
-                "cloudtrail.amazonaws.com",
-                "config.amazonaws.com",
-            ],
-            feature_set="ALL")
-
-    # Check if an aws org exists for this account
-    def org_exists(self):
-        if self.org.id == "" or self.org.id is none:
-            return False
-        else:
-            return True
-
 # Initialize configuration
 config = pulumi.Config()
 public_key = config.require('publickey')
 private_key = config.require_secret('privatekey')
 extip = requests.get('http://checkip.amazonaws.com/')
-organization = asterion_organization(
+organization = asterion_organization.org(
     'asterion-infra-aws',
     aws.organizations.get_organization())
 

--- a/infra-aws/asterion_organization.py
+++ b/infra-aws/asterion_organization.py
@@ -1,0 +1,25 @@
+# Create a class that models the asterion aws organization
+class org:
+
+    # Default constructor
+    def __init__(self, name, org):
+        self.name = name
+        self.org = org
+
+    # Create an aws org for the current account
+    def create_org(self):
+        
+        # Create an organization for this current account
+        self.org = aws.organizations.Organization(self.name,
+            aws_service_access_principals=[
+                "cloudtrail.amazonaws.com",
+                "config.amazonaws.com",
+            ],
+            feature_set="ALL")
+
+    # Check if an aws org exists for this account
+    def org_exists(self):
+        if self.org.id == "" or self.org.id is none:
+            return False
+        else:
+            return True

--- a/infra-aws/guides/create-asterion-infra-aws-org.org
+++ b/infra-aws/guides/create-asterion-infra-aws-org.org
@@ -1,6 +1,6 @@
 #+TITLE: Asterion infrastructure deployment
 #+AUTHOR: James Blair, Shawn Gerrard, Daljit Singh
-#+DATE: <2022-03-12 Sat>
+#+DATE: <2022-04-19 Tue>
 
 
 This repository captures the end to end workflow for deploying asterion digital infrastructure via [[https://www.pulumi.com/][pulumi]].


### PR DESCRIPTION
Activating aws organizations as part of our pulumi infrastructure deployment will provide the foundations for modelling our organizational accounts, billing, and policies in future. 

This update will ensure that either the organization for the current account is obtained by pulumi, or a call is made to aws to create an organization for the account. The `asterion_organization.py` module will contain repeatable classes that will be utilized to form the final asterion aws org model, such as the creation and manipulation of org units and member accounts.