### PR TITLE
Configure org-asterion-dev stack with new roles and permissions

### DIFF
--- a/org-asterion-dev/README.org
+++ b/org-asterion-dev/README.org
@@ -1,0 +1,69 @@
+#+TITLE: Asterion infrastructure deployment
+#+AUTHOR: James Blair, Shawn Gerrard, Daljit Singh
+#+DATE: <2022-03-12 Sat>
+
+
+This repository captures the end to end workflow for deploying asterion digital aws organization and iam via [[https://www.pulumi.com/][pulumi]].
+
+Please note that this stack requires the [[https://github.com/asterion-digital/asterion-as-code/tree/master/org-asterion][org-asterion]] pulumi stack brought `up`.
+
+
+* Setup environment
+
+To get started lets initialise our project, making sure we are in the right directory, have the python [[https://docs.python.org/3/library/venv.html][virtual environment]] activated, and have installed our python dependencies with [[https://pypi.org/project/pip/][pip]].
+
+#+NAME: Setup environment
+#+begin_src tmate
+# Start from the infra directory and initialise
+cd org-asterion-dev && pulumi stack init dev
+
+# Create virtual environment
+python3 -m venv venv
+
+# Activate virtual environment
+source venv/bin/activate
+
+# Install pip requirements
+pip install -r requirements.txt
+#+end_src
+
+
+* Create configuration
+
+Once our local environment is set up we can proceed with creating the required configuration entries in pulumi.
+
+You can obtain the organization name of your pulumi account from the [[https://app.pulumi.com/signin][pulumi console]].
+
+#+NAME: Create required pulumi configuration
+#+begin_src tmate
+echo "<org name>" | pulumi config set org
+#+end_src
+
+If you didn't install AWS CLI as per previous instructions, you will need to configure pulumi with a [[https://www.pulumi.com/registry/packages/aws/installation-configuration/][few more details]].
+
+
+* Create stack and retrieve kubeconfig
+
+Once we have our local pulumi configuration set we can bring up the organizational stack.
+
+Currently this stack includes construction of the asterion organization in aws, with iam users and login profiles, as well as aws accounts to manage resources in different development environments, and roles that administrative iam users can assume to access these accounts.
+
+#+NAME: Bring the stack up
+#+begin_src tmate
+pulumi up --yes
+#+end_src
+
+Asterion organization has now been deployed in aws! 🚀
+
+
+* Teardown stack
+
+Need to make it all go away 😅?  No problem, run the following to completely teardown this stack.
+
+#+NAME: Teardown down the pulumi stack
+#+begin_src tmate
+pulumi destroy --yes
+#+end_src
+
+
+From here, you can sign-in as one of the users, using the appropriate password in the pulumi output, into the aws console and create access keys to be able to interact with aws programatically or through the CLI.

--- a/org-asterion-dev/__main__.py
+++ b/org-asterion-dev/__main__.py
@@ -73,7 +73,7 @@ assume_role_policy_document = aws.iam.get_policy_document(
             effect="Allow",
             principals=[
                 aws.iam.GetPolicyDocumentStatementPrincipalArgs(
-                    identifiers=[Output.concat("arn:aws:iam::",root_account_id,":group/admins")],
+                    identifiers=[Output.concat("arn:aws:iam::",root_account_id,":group/asterion-admins")],
                     type="AWS"
                 )
             ]

--- a/org-asterion-dev/__main__.py
+++ b/org-asterion-dev/__main__.py
@@ -2,9 +2,11 @@
 
 import pulumi
 import pulumi_aws as aws
+import json
+from pulumi import Config, Output
 
 # Obtain the pulumi configuration
-config = pulumi.Config()
+config = Config()
 
 # Ensure we obtain the stacks from the proper environment (E.G 'dev', 'prod' etc)
 stack = pulumi.get_stack()
@@ -15,6 +17,10 @@ org = config.require("currentOrg")
 # Obtain the `org-asterion` pulumi stack
 org_asterion_stack = pulumi.StackReference(f"{org}/org-asterion/{stack}")
 
+# Obtain `org-asterion` output objects
+root_account_id = org_asterion_stack.get_output("Asterion aws org account id")
+dev_account_id = org_asterion_stack.get_output("Dev Account ID")
+
 # Export the dev aws account id from the `org-asterion` stack
-pulumi.export("org-asterion AWS Account ID", org_asterion_stack.get_output("Asterion aws org account id"))
-pulumi.export("org-asterion-dev AWS Account ID", org_asterion_stack.get_output("Dev Account ID"))
+pulumi.export("org-asterion AWS Account ID", root_account_id)
+pulumi.export("org-asterion-dev AWS Account ID", dev_account_id)

--- a/org-asterion-dev/__main__.py
+++ b/org-asterion-dev/__main__.py
@@ -18,9 +18,94 @@ org = config.require("currentOrg")
 org_asterion_stack = pulumi.StackReference(f"{org}/org-asterion/{stack}")
 
 # Obtain `org-asterion` output objects
-root_account_id = org_asterion_stack.get_output("Asterion aws org account id")
-dev_account_id = org_asterion_stack.get_output("Dev Account ID")
+root_account_id = org_asterion_stack.get_output("asterion org account id")
+dev_account_id = org_asterion_stack.get_output("asterion dev account id")
 
 # Export the dev aws account id from the `org-asterion` stack
-pulumi.export("org-asterion AWS Account ID", root_account_id)
-pulumi.export("org-asterion-dev AWS Account ID", dev_account_id)
+pulumi.export("org-asterion aws account id", root_account_id)
+pulumi.export("org-asterion-dev aws account id", dev_account_id)
+
+# Create a provider that will assume the default `OrganizationAccountAccessRole` role in the asterion-dev account
+provider = aws.Provider(
+    "asterion-dev-account-provider",
+    assume_role=aws.ProviderAssumeRoleArgs(
+        role_arn=Output.concat("arn:aws:iam::",dev_account_id,":role/OrganizationAccountAccessRole"),
+        session_name="PulumiSession",
+        external_id="PulumiApplication"
+    ),
+    region=config.require('region')
+)
+
+# Create an alias for the asterion-dev account
+alias = aws.iam.AccountAlias(
+    "asterion-dev-account-alias",
+    account_alias="asteriondev",
+    opts=pulumi.ResourceOptions(
+        provider=provider
+    )
+)
+
+# Define an inline policy document in the asterion dev account for resource permissions
+asterion_dev_policy_document = aws.iam.get_policy_document(
+    statements=[
+        aws.iam.GetPolicyDocumentStatementArgs(
+            actions=[
+                "ec2:*"
+            ],
+            effect="Allow",
+            resources=[
+                Output.concat("arn:aws:ec2::",dev_account_id,":*")
+            ]
+        )
+    ],
+    opts=pulumi.InvokeOptions(
+        provider=provider
+    )
+)
+
+# Define a policy document allowing iam `admins` group to assume a role in the asterion-dev account
+assume_role_policy_document = aws.iam.get_policy_document(
+    statements=[
+        aws.iam.GetPolicyDocumentStatementArgs(
+            actions=[
+                "sts:AssumeRole"
+            ],
+            effect="Allow",
+            principals=[
+                aws.iam.GetPolicyDocumentStatementPrincipalArgs(
+                    identifiers=[Output.concat("arn:aws:iam::",root_account_id,":group/admins")],
+                    type="AWS"
+                )
+            ]
+        )
+    ],
+    opts=pulumi.InvokeOptions(
+        provider=provider
+    )
+)
+
+# Create a new role in the asterion-dev account 
+admin_dev_role = aws.iam.Role(
+    "asterion-dev-admin-role",
+    assume_role_policy=assume_role_policy_document.json,
+    inline_policies=[
+        aws.iam.RoleInlinePolicyArgs(
+            name="asterion-dev-resource-policy",
+            policy=asterion_dev_policy_document.json
+        )
+    ],
+    opts=pulumi.ResourceOptions(provider=provider)
+)
+
+# Create a new role in the asterion dev account 
+admin_dev_role = aws.iam.Role(
+    "asterion-dev-admin-role",
+    assume_role_policy=assume_role_policy_document.json,
+    inline_policies=[
+        aws.iam.RoleInlinePolicyArgs(
+            name="asterion-dev-resource-policy",
+            policy=asterion_dev_policy_document.json
+        )
+    ],
+    opts=pulumi.ResourceOptions(provider=provider)
+)

--- a/org-asterion/README.org
+++ b/org-asterion/README.org
@@ -30,9 +30,11 @@ pip install -r requirements.txt
 
 Once our local environment is set up we can proceed with creating the required configuration entries in pulumi.
 
+The `newUsernames` config value can be a list seperated by the following characters: (;,.-%)
+
 #+NAME: Create required pulumi configuration
 #+begin_src tmate
-echo "<user name>" | pulumi config set newUsername
+echo "<username1>,<username2>,<username3>" | pulumi config set newUsernames
 #+end_src
 
 If you didn't install AWS CLI as per previous instructions, you will need to configure pulumi with a [[https://www.pulumi.com/registry/packages/aws/installation-configuration/][few more details]].

--- a/org-asterion/__main__.py
+++ b/org-asterion/__main__.py
@@ -193,3 +193,55 @@ provider = aws.Provider(
     ),
     region=aws_config.require('region')
 )
+
+#########################################################################################
+# Apply configurations to asterion-dev aws account below
+#########################################################################################
+
+# Define an inline policy document in the asterion dev account for resource permissions
+asterion_dev_policy_document = aws.iam.get_policy_document(
+    statements=[
+        aws.iam.GetPolicyDocumentStatementArgs(
+            actions=[
+                "ec2:*"
+            ],
+            effect="Allow",
+            resources=[
+                Output.concat("arn:aws:ec2::",asterion_infra_aws_dev_acc.id,":*")
+            ]
+        )
+    ],
+    opts=pulumi.InvokeOptions(provider=provider)
+)
+
+# Define a policy document that allows the administrator role to be assumed
+assume_role_policy_document = aws.iam.get_policy_document(
+    statements=[
+        aws.iam.GetPolicyDocumentStatementArgs(
+            actions=[
+                "sts:AssumeRole"
+            ],
+            effect="Allow",
+            principals=[
+                aws.iam.GetPolicyDocumentStatementPrincipalArgs(
+                    identifiers=[Output.concat("arn:aws:iam::",asterion_infra_aws_org.org.master_account_id,":user/administrator")],
+                    type="AWS"
+                )
+            ]
+        )
+    ],
+    opts=pulumi.InvokeOptions(provider=provider)
+)
+
+# Create a new role in the asterion dev account 
+admin_dev_role = aws.iam.Role(
+    "asterion-dev-admin-role",
+    assume_role_policy=assume_role_policy_document.json,
+    inline_policies=[
+        aws.iam.RoleInlinePolicyArgs(
+            name="asterion-dev-resource-policy",
+            policy=asterion_dev_policy_document.json
+        )
+    ],
+    opts=pulumi.ResourceOptions(provider=provider)
+)

--- a/org-asterion/__main__.py
+++ b/org-asterion/__main__.py
@@ -166,7 +166,7 @@ admin_team = aws.iam.GroupMembership(
 try:
     asterion_infra_aws_dev_acc = aws.organizations.Account(
         "asterion-dev-account",
-        email="devRRN8XsdN9wHjpYD4KxW9sLx7@asterion.digital",
+        email="asterion-dev-team@asterion.digital",
         name="Asterion Infra-AWS Dev Team",
         parent_id=asterion_infra_aws_dev.id,
         opts=pulumi.ResourceOptions(retain_on_delete=True)
@@ -178,7 +178,7 @@ except BaseException as err:
 try:
     asterion_infra_aws_test_acc = aws.organizations.Account(
         "asterion-test-account",
-        email="testn6beRpTPbZ4j8JiX5CLX6xvH2@asterion.digital",
+        email="asterion-test-team@asterion.digital",
         name="Asterion Infra-AWS Test Team",
         parent_id=asterion_infra_aws_test.id,
         opts=pulumi.ResourceOptions(retain_on_delete=True)
@@ -190,7 +190,7 @@ except BaseException as err:
 try:
     asterion_infra_aws_prod_acc = aws.organizations.Account(
         "asterion-prod-account",
-        email="prodmBJxpyCjBqcW8xhMwdfBkhtH@asterion.digital",
+        email="asterion-prod-team@asterion.digital",
         name="Asterion Infra-AWS Prod Team",
         parent_id=asterion_infra_aws_prod.id,
         opts=pulumi.ResourceOptions(retain_on_delete=True)

--- a/org-asterion/__main__.py
+++ b/org-asterion/__main__.py
@@ -155,3 +155,26 @@ except BaseException as err:
 pulumi.export("Dev Account ID", asterion_infra_aws_dev_acc.id)
 pulumi.export("Test Account ID", asterion_infra_aws_test_acc.id)
 pulumi.export("Production Account ID", asterion_infra_aws_prod_acc.id)
+
+# Create a policy document for the assumerole policies
+assumerole_policy_document = aws.iam.get_policy_document(
+    statements=[
+        aws.iam.GetPolicyDocumentStatementArgs(
+            actions=[
+                "sts:AssumeRole"
+            ],
+            effect="Allow",
+            resources=[
+                Output.concat("arn:aws:iam::",asterion_infra_aws_dev_acc.id,":role/Administrator"),
+                Output.concat("arn:aws:iam::",asterion_infra_aws_test_acc.id,":role/Administrator"),
+                Output.concat("arn:aws:iam::",asterion_infra_aws_prod_acc.id,":role/Administrator")
+            ]
+        )
+    ]
+)
+
+# Attach the assumerole policy document to the admins group policy
+admin_group_assumerole_policy = aws.iam.GroupPolicy("asterion-group-admins-policy",
+    group=admin_group.name,
+    policy=assumerole_policy_document.json
+)


### PR DESCRIPTION
We need to provision the new `org-asterion-dev` stack with aws roles that iam users in other accounts can assume, in order to provision and maintain further aws resources.

We also need to create iam users and provide them with the ability to log in to the console.